### PR TITLE
Fix plugins not being available

### DIFF
--- a/fusion.sh
+++ b/fusion.sh
@@ -6,8 +6,11 @@ kega_localdir="$XDG_CONFIG_HOME/.Kega Fusion"
 # create local plugins directory if not present
 mkdir -p "$kega_localdir/Plugins"
 
+# remove dead link
+rm -f "$kega_localdir/Plugins/"[*]
+
 # create links for every included plugin
-for i in $kega_libdir/plugins/*; do
+for i in $kega_libdir/Plugins/*; do
   if [ ! -e "$kega_localdir/Plugins/$(basename "$i")" ]; then
     ln -sf "$i" "$kega_localdir/Plugins/"
   fi

--- a/local-build.sh
+++ b/local-build.sh
@@ -4,5 +4,7 @@ rm -f com.carpeludum.KegaFusion.flatpak
 rm -rf _build ; mkdir _build
 rm -rf _repo ; mkdir _repo
 
-flatpak-builder --ccache --force-clean _build com.carpeludum.KegaFusion.yml --repo=_repo
-flatpak build-bundle _repo com.carpeludum.KegaFusion.flatpak com.carpeludum.KegaFusion master
+BRANCH=test
+
+flatpak-builder --ccache --force-clean --default-branch=$BRANCH _build com.carpeludum.KegaFusion.yml --repo=_repo
+flatpak build-bundle _repo com.carpeludum.KegaFusion.flatpak com.carpeludum.KegaFusion $BRANCH


### PR DESCRIPTION
Overwrite dlopen() with our script so we can change the location of
the target file, as the plugins path is hard-coded in Kega Fusion.

Closes: #2
